### PR TITLE
feat: refactored get_response to allow for better rate control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,8 @@ test_output/
 private*.json
 token*.json
 *.env
+*.venv
 !EXAMPLE.env
+
+.vscode
+.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-bandit==1.7.4
-coverage==6.5.0
-flake8==5.0.4
-pytest==7.1.3
-python-dotenv==0.21.0
-requests==2.28.1
+bandit==1.7.5
+coverage==7.2.7
+flake8==6.0.0
+pytest==7.4.0
+python-dotenv==1.0.0
+requests==2.31.0
 stringcase==1.2.0
 yahoo-oauth==2.0


### PR DESCRIPTION
Moved retries and backoff into the __init__ function for user control over request limitations.