### PR TITLE
get_team_stats_by_week fails when there is no team_projected_points for a league(for an ended league) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ test_output/
 *private*.json
 !private.template.json
 *token*.json
+venv/

--- a/yfpy/models.py
+++ b/yfpy/models.py
@@ -889,6 +889,28 @@ class TeamProjectedPoints(YahooFantasyObject):
 
 
 # noinspection PyUnresolvedReferences
+class TeamStats(YahooFantasyObject):
+    """Model class for "team_stats" data key.
+    """
+
+    def __init__(self, extracted_data):
+        """Instantiate the TeamStats child class of YahooFantasyObject.
+
+        Args:
+            extracted_data (dict): Parsed and cleaned JSON data retrieved from the Yahoo Fantasy Sports REST API.
+
+        Attributes:
+            coverage_type (str): The timeframe for the selected team stats ("week", "date", "season", etc.).
+            week (int): The week number.
+            stats (list[Stat]): List of Stat objects containing the team's statistics.
+        """
+        YahooFantasyObject.__init__(self, extracted_data)
+        self.coverage_type: str = self._extracted_data.get("coverage_type", "")
+        self.week: Optional[int] = self._extracted_data.get("week", None)
+        self.stats: List[Stat] = self._extracted_data.get("stats", [])
+
+
+# noinspection PyUnresolvedReferences
 class TeamStandings(YahooFantasyObject):
     """Model class for "team_standings" data key.
     """
@@ -1777,3 +1799,4 @@ class TransactionData(YahooFantasyObject):
         self.source_team_name: str = self._extracted_data.get("source_team_name", "")
         self.source_type: str = self._extracted_data.get("source_type", "")
         self.type: str = self._extracted_data.get("type", "")
+

--- a/yfpy/models.py
+++ b/yfpy/models.py
@@ -528,6 +528,9 @@ class Team(YahooFantasyObject):
             team_projected_points (TeamProjectedPoints): A YFPY TeamProjectedPoints instance.
             projected_points (float): The total projected points for the team.
             team_standings (TeamStandings): A YFPY TeamStandings instance.
+            team_stats (TeamStats): A YFPY TeamStats instance containing the team's statistics.
+            team_remaining_games (TeamRemainingGames): A YFPY TeamRemainingGames instance containing information about
+                remaining games for the team.
             wins (int): The number of wins by the team.
             losses (int): The number of losses by the team.
             ties (int): The number of ties by the team.
@@ -587,10 +590,11 @@ class Team(YahooFantasyObject):
         self.team_paid: int = self._extracted_data.get("team_paid", 0)
         self.team_points: TeamPoints = self._extracted_data.get("team_points", TeamPoints({}))
         self.points: float = self._get_nested_value(self.team_points, "total", 0.0, float)
-        self.team_projected_points: TeamProjectedPoints = self._extracted_data.get("team_projected_points",
-                                                                                   TeamProjectedPoints({}))
+        self.team_projected_points: TeamProjectedPoints = self._extracted_data.get("team_projected_points", TeamProjectedPoints({}))
         self.projected_points: float = self._get_nested_value(self.team_projected_points, "total", 0.0, float)
         self.team_standings: TeamStandings = self._extracted_data.get("team_standings", TeamStandings({}))
+        self.team_stats: TeamStats = self._extracted_data.get("team_stats", TeamStats({}))
+        self.team_remaining_games: TeamRemainingGames = self._extracted_data.get("team_remaining_games", TeamRemainingGames({}))
         self.wins: int = self._get_nested_value(self.team_standings, ["outcome_totals", "wins"], 0, int)
         self.losses: int = self._get_nested_value(self.team_standings, ["outcome_totals", "losses"], 0, int)
         self.ties: int = self._get_nested_value(self.team_standings, ["outcome_totals", "ties"], 0, int)
@@ -886,6 +890,33 @@ class TeamProjectedPoints(YahooFantasyObject):
         self.coverage_type: str = self._extracted_data.get("coverage_type", "")
         self.total: float = self._get_nested_value(self._extracted_data, "total", 0.0, float)
         self.week: Optional[int] = self._extracted_data.get("week", None)
+
+# noinspection PyUnresolvedReferences
+class TeamRemainingGames(YahooFantasyObject):
+    """Model class for "team_remaining_games" data key.
+    """
+
+    def __init__(self, extracted_data):
+        """Instantiate the TeamRemainingGames child class of YahooFantasyObject.
+
+        Args:
+            extracted_data (dict): Parsed and cleaned JSON data retrieved from the Yahoo Fantasy Sports REST API.
+
+        Attributes:
+            coverage_type (str): The timeframe for the remaining games data ("week", "date", "season", etc.).
+            week (int): The week number.
+            total (dict): Dictionary containing remaining games statistics:
+                remaining_games (int): Number of remaining games.
+                live_games (int): Number of currently live games.
+                completed_games (int): Number of completed games.
+        """
+        YahooFantasyObject.__init__(self, extracted_data)
+        self.coverage_type: str = self._extracted_data.get("coverage_type", "")
+        self.week: Optional[int] = self._extracted_data.get("week", None)
+        self.total: dict = self._extracted_data.get("total", {})
+        self.remaining_games: int = self._get_nested_value(self.total, "remaining_games", 0, int)
+        self.live_games: int = self._get_nested_value(self.total, "live_games", 0, int)
+        self.completed_games: int = self._get_nested_value(self.total, "completed_games", 0, int)
 
 
 # noinspection PyUnresolvedReferences
@@ -1799,4 +1830,3 @@ class TransactionData(YahooFantasyObject):
         self.source_team_name: str = self._extracted_data.get("source_team_name", "")
         self.source_type: str = self._extracted_data.get("source_type", "")
         self.type: str = self._extracted_data.get("type", "")
-

--- a/yfpy/query.py
+++ b/yfpy/query.py
@@ -522,16 +522,16 @@ class YahooFantasySportsQuery(object):
                     if isinstance(data_key_list[i], list):
                         reformatted = reformat_json_list(raw_response_data)
                         raw_response_data = [
-                            {data_key_list[i][0]: reformatted[data_key_list[i][0]]},
-                            {data_key_list[i][1]: reformatted[data_key_list[i][1]]}
+                            {key: reformatted[key]} for key in data_key_list[i]
+                            if key in reformatted
                         ]
                     else:
                         raw_response_data = reformat_json_list(raw_response_data)[data_key_list[i]]
                 else:
                     if isinstance(data_key_list[i], list):
                         raw_response_data = [
-                            {data_key_list[i][0]: raw_response_data[data_key_list[i][0]]},
-                            {data_key_list[i][1]: raw_response_data[data_key_list[i][1]]}
+                            {key: raw_response_data[key]} for key in data_key_list[i]
+                            if key in raw_response_data
                         ]
                     else:
                         raw_response_data = raw_response_data.get(data_key_list[i])
@@ -2124,7 +2124,7 @@ class YahooFantasySportsQuery(object):
         team_key = f"{self.get_league_key()}.t.{team_id}"
         return self.query(
             f"https://fantasysports.yahooapis.com/fantasy/v2/team/{team_key}/stats;type=week;week={chosen_week}",
-            ["team", ["team_points", "team_projected_points"]]
+            ["team", ["team_points", "team_stats", "team_projected_points"]]
         )
 
     def get_team_standings(self, team_id: Union[str, int]) -> TeamStandings:

--- a/yfpy/query.py
+++ b/yfpy/query.py
@@ -46,6 +46,7 @@ from yfpy.models import (
     TeamPoints,
     TeamProjectedPoints,
     TeamStandings,
+    TeamStats,
     Transaction,
     User,
     YahooFantasyObject
@@ -2090,7 +2091,7 @@ class YahooFantasySportsQuery(object):
 
     def get_team_stats_by_week(
             self, team_id: Union[str, int], chosen_week: Union[int, str] = "current"
-    ) -> Dict[str, Union[TeamPoints, TeamProjectedPoints]]:
+    ) -> Dict[str, Union[TeamPoints, TeamStats, TeamProjectedPoints]]:
         """Retrieve stats of specific team by team_id and by week for chosen league.
 
         Args:
@@ -2113,12 +2114,26 @@ class YahooFantasySportsQuery(object):
                 "coverage_type": "week",
                 "total": "78.85",
                 "week": "1"
+              }),
+              "team_stats": TeamStats({
+                "coverage_type": "week",
+                "week": "1",
+                "stats": [
+                  {
+                    "stat": {
+                      "stat_id": "4",
+                      "value": "249"
+                    }
+                  },
+                  ...
+                ]
               })
             }
 
         Returns:
-            dict[str, TeamPoints | TeamProjectedPoints]: Dictionary containing keys "team_points" and
-                "team_projected_points" with respective values YFPY TeamPoints and YFPY TeamProjectedPoints instances.
+            dict[str, TeamPoints | TeamProjectedPoints | TeamStats]: Dictionary containing keys "team_points", 
+                "team_projected_points", and "team_stats" with respective values YFPY TeamPoints, YFPY TeamProjectedPoints,
+                and YFPY TeamStats instances.
 
         """
         team_key = f"{self.get_league_key()}.t.{team_id}"

--- a/yfpy/query.py
+++ b/yfpy/query.py
@@ -2856,6 +2856,35 @@ class YahooFantasySportsQuery(object):
             f"https://fantasysports.yahooapis.com/fantasy/v2/team/{team_key}/matchups",
             ["team", "matchups"]
         )
+  
+    def get_team_matchup_by_week(self, team_id: Union[str, int], chosen_week: Union[int, str]) -> Matchup:
+        """Retrieve matchup of specific team by team_id for a specific week in the chosen league.
+
+        Args:
+            team_id (str | int): Selected team ID for which to retrieve data (can be integers 1 through n where n is the
+                number of teams in the league).
+            chosen_week (Union[int, str]): Week number to get matchup for.
+
+        Examples:
+            >>> from pathlib import Path
+            >>> from yfpy.query import YahooFantasySportsQuery
+            >>> query = YahooFantasySportsQuery(league_id="######", game_code="nfl")
+            >>> # Get matchup for a specific week
+            >>> query.get_team_matchup_by_week(1, 5)
+            Matchup({
+              <matchup data> (see get_league_matchups_by_week docstring for matchup data example)
+            })
+
+        Returns:
+            Matchup: YFPY Matchup instance for the specified week.
+
+        """
+        team_key = f"{self.get_league_key()}.t.{team_id}"
+        return self.query(
+            f"https://fantasysports.yahooapis.com/fantasy/v2/team/{team_key}/matchups;weeks={chosen_week}",
+            ["team", "matchups", "0", "matchup"],
+            Matchup
+        )
 
     def get_player_stats_for_season(self, player_key: str, limit_to_league_stats: bool = True) -> Player:
         """Retrieve stats of specific player by player_key for the entire season for chosen league.

--- a/yfpy/query.py
+++ b/yfpy/query.py
@@ -2141,6 +2141,159 @@ class YahooFantasySportsQuery(object):
             f"https://fantasysports.yahooapis.com/fantasy/v2/team/{team_key}/stats;type=week;week={chosen_week}",
             ["team", ["team_points", "team_stats", "team_projected_points"]]
         )
+    
+    def get_teams_stats_by_week(self, team_ids: List[Union[str, int]], chosen_week: Union[int, str] = "current") -> List[Team]:
+      """Get stats for multiple teams for a specific week.
+
+      Args:
+          team_ids (List[Union[str, int]]): List of team IDs to get stats for
+          chosen_week (Union[int, str], optional): Week number to get stats for. Defaults to "current".
+
+      Examples:
+            >>> from yfpy.query import YahooFantasySportsQuery
+            >>> query = YahooFantasySportsQuery(league_id="#####", game_code="nba")
+            >>> query.get_teams_stats_by_week([1, 2], 22)
+            [
+              {
+                "clinched_playoffs": 1,
+                "draft_position": 4,
+                "has_draft_grade": 0,
+                "league_scoring_type": "head",
+                "managers": {
+                  "manager": {
+                    "email": "manager1@example.com",
+                    "felo_score": 801,
+                    "felo_tier": "platinum",
+                    "guid": "ABCD1234EFGH5678IJKL9012MN",
+                    "image_url": "https://s.yimg.com/ag/images/sample_profile_64sq.jpg",
+                    "is_commissioner": 0,
+                    "manager_id": 1,
+                    "nickname": "Manager1"
+                  }
+                },
+                "name": "Team Alpha",
+                "number_of_moves": 81,
+                "number_of_trades": 0,
+                "roster_adds": {
+                  "coverage_type": "week",
+                  "coverage_value": 23,
+                  "value": 0
+                },
+                "team_id": 1,
+                "team_key": "454.l.######.t.1",
+                "team_logos": {
+                  "team_logo": {
+                    "size": "large",
+                    "url": "https://yahoofantasysports-res.cloudinary.com/image/upload/t_s192sq/fantasy-logos/0adf0d289fa54e02c4e3a6d8e99533ff29f1f93b22b7392cfd4fac4951f4c627.jpg"
+                  }
+                },
+                "team_points": {
+                  "coverage_type": "week",
+                  "total": 5.0,
+                  "week": 22
+                },
+                "team_stats": {
+                  "coverage_type": "week",
+                  "week": 22,
+                  "stats": [
+                    {
+                      "stat": {
+                        "stat_id": 9004003,
+                        "value": 0.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 5,
+                        "value": 0.445
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 9007006,
+                        "value": 0.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 8,
+                        "value": 0.822
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 10,
+                        "value": 86.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 12,
+                        "value": 772.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 15,
+                        "value": 268.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 16,
+                        "value": 178.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 17,
+                        "value": 56.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 18,
+                        "value": 34.0
+                      }
+                    },
+                    {
+                      "stat": {
+                        "stat_id": 19,
+                        "value": 80.0
+                      }
+                    }
+                  ]
+                },
+                "url": "https://basketball.fantasysports.yahoo.com/nba/######/1",
+                "team_remaining_games": {
+                  "coverage_type": "week",
+                  "week": 22,
+                  "total": {
+                    "remaining_games": 0,
+                    "live_games": 0,
+                    "completed_games": 58
+                  }
+                }
+              },
+              ...
+            ]
+
+      Returns:
+          List[Team]: List of YFPY Team instances containing comprehensive team data for the specified week. Each Team
+              instance includes team_points (TeamPoints), team_stats (TeamStats), team_remaining_games 
+              (TeamRemainingGames), managers (Manager), roster_adds (RosterAdds), team_logos (TeamLogo), and other 
+              team-related attributes populated with week-specific statistical data.
+      
+      """
+      # Convert team IDs to team keys using game_code from initialization and league ID (52687)
+      team_keys = [f"{self.get_league_key()}.t.{team_id}" for team_id in team_ids]
+      team_keys_str = ",".join(team_keys)
+      return self.query(
+          f"https://fantasysports.yahooapis.com/fantasy/v2/teams;team_keys={team_keys_str}/stats;type=week;week={chosen_week}",
+          ["teams"]
+      )
+    
+
 
     def get_team_standings(self, team_id: Union[str, int]) -> TeamStandings:
         """Retrieve standings of specific team by team_id for chosen league.


### PR DESCRIPTION
Fixes #64 
Might also help for #60

- Also added "team_stats" to the same method to return stats for H2H leagues. 
- Refactored query method to handle response creation dynamically so it shouldn't fail in case any of the keys in **data_key_list** is missing in the response.

So the response in my case looks like:
![image](https://github.com/user-attachments/assets/4b223754-e634-4e8b-8bdb-c206d5f40f05)

Tests seem to work fine afterwards:
![image](https://github.com/user-attachments/assets/5e73955b-32d6-4e13-a035-26a0bbb93036)



Edit:

I also added a new feature to get stats from multiple team in one request for given week:
def get_teams_stats_by_week(self, team_ids: List[Union[str, int]], chosen_week: Union[int, str] = "current") -> List[Team]:

Which also returns TeamRemainingGames as part of the request. I added relevant model class to parse the response.

Edit2:
Also added get_team_matchup_by_week method to get a specific matchup for the week.


